### PR TITLE
Added PPC and TRC to currencies

### DIFF
--- a/btceapi/common.py
+++ b/btceapi/common.py
@@ -3,7 +3,7 @@ import json
 
 btce_domain = "btc-e.com"
 
-all_currencies = ("btc", "usd", "rur", "ltc", "nmc", "eur", "nvc")  
+all_currencies = ("btc", "usd", "rur", "ltc", "nmc", "eur", "nvc", "trc", "ppc")  
 all_pairs = ("btc_usd", "btc_rur", "ltc_btc", "ltc_usd", "ltc_rur",
              "nmc_btc", "usd_rur", "eur_usd", "nvc_btc", "trc_btc",
              "ppc_btc")


### PR DESCRIPTION
Before this, while you could query the depth on the exchange for TRC and PPC, you were unable to get the balance of one of these currencies of an account.
