### PR TITLE
Update Digit Truncation to Rounding

### DIFF
--- a/btceapi/common.py
+++ b/btceapi/common.py
@@ -72,7 +72,7 @@ def validatePair(pair):
         raise Exception("Unrecognized pair: %r" % pair)
         
 def formatCurrency(value, maxdigits):
-    s = round(s, maxdigits)
+    s = round(value, maxdigits)
     s = "%.8f" % value
     s = s[:s.index(".")+maxdigits+1]
     


### PR DESCRIPTION
At the moment, if more digits than the normally allowed maximum are specified, additional digits will be truncated away rather than being rounded. This may seem small, but for those writing automated traders based on this library, it might be significant after many trades. Added in a round() before converting the value to a string and truncating. Please merge if you feel appropriate.
