### PR TITLE
Allow subtypes for btceapi.keyhandler.KeyHandler

### DIFF
--- a/btceapi/trade.py
+++ b/btceapi/trade.py
@@ -136,7 +136,7 @@ class TradeAPI(object):
         self.key = key
         self.handler = handler
 
-        if type(self.handler) is not keyhandler.KeyHandler:
+        if not isinstance(self.handler, keyhandler.KeyHandler):
             raise Exception("The handler argument must be a"
                             " keyhandler.KeyHandler")
 


### PR DESCRIPTION
This would also allow subtyped btceapi.keyhandler.KeyHandler instances. An example of a subtyped KeyHandler class might be one that defines a close() function so the KeyHandler can be used with the 'with' syntax.

```
#!/usr/bin/env python

from contextlib import closing
import btceapi
import mybtceconfig

class ClosableKeyHandler(btceapi.KeyHandler):
    def __init__(self, filename):
        super(ClosableKeyHandler, self).__init__(filename, True)

    def close(self):
        self.save(self.filename)

with closing(ClosableKeyHandler(mybtceconfig.keyFile())) as keyHandler:
    tapi = btceapi.TradeAPI(mybtceconfig.key(), keyHandler)
    info = tapi.getInfo()
    print 'Current balance (USD): %s' % info.balance_usd
```
