### PR TITLE
Relative imports

### DIFF
--- a/btceapi/public.py
+++ b/btceapi/public.py
@@ -3,7 +3,7 @@
 import datetime
 import decimal
 
-from btceapi import common
+from . import common
 
 
 def getTradeFee(pair, connection=None):

--- a/btceapi/scraping.py
+++ b/btceapi/scraping.py
@@ -3,7 +3,7 @@
 from HTMLParser import HTMLParser
 import datetime
 import warnings
-from btceapi.common import BTCEConnection, all_pairs
+from .common import BTCEConnection, all_pairs
 
 
 class BTCEScraper(HTMLParser):

--- a/btceapi/trade.py
+++ b/btceapi/trade.py
@@ -6,8 +6,8 @@ import hmac
 import warnings
 from datetime import datetime
 
-from btceapi import common
-from btceapi import keyhandler
+from . import common
+from . import keyhandler
 
 
 class InvalidNonceException(Exception):


### PR DESCRIPTION
Relative imports is widely used in popular projects like Flask, requests, ... 

And it's required for vendorizing this package considering it's not yet very stable.
