### PR TITLE
Separating concerns for the `KeyHandler` class

### DIFF
--- a/btceapi/__init__.py
+++ b/btceapi/__init__.py
@@ -3,7 +3,7 @@
 from public import getDepth, getTicker, getTradeFee, getTradeHistory
 from trade import TradeAPI
 from scraping import scrapeMainPage
-from keyhandler import KeyHandler
+from keyhandler import AbstractKeyHandler, KeyHandler
 from common import all_currencies, all_pairs, max_digits, min_orders, \
     formatCurrency, formatCurrencyDigits, \
     truncateAmount, truncateAmountDigits, \

--- a/btceapi/keyhandler.py
+++ b/btceapi/keyhandler.py
@@ -3,83 +3,132 @@
 import warnings
 
 
+class InvalidNonceException(Exception):
+    '''Exception raised when an invalid nonce is set on a key.'''
+    pass
+
+
 class KeyData(object):
     def __init__(self, secret, nonce):
         self.secret = secret
         self.nonce = nonce
 
+    # BTC-e's API caps nonces' values
+    MAX_NONCE_VALUE = 4294967294
 
-class KeyHandler(object):
-    '''KeyHandler handles the tedious task of managing nonces associated
-    with a BTC-e API key/secret pair.
-    The getNextNonce method is threadsafe, all others are not.'''
-    def __init__(self, filename=None, resaveOnDeletion=True):
-        '''The given file is assumed to be a text file with three lines
-        (key, secret, nonce) per entry.'''
-        if not resaveOnDeletion:
-            warnings.warn("The resaveOnDeletion argument to KeyHandler will"
-                          " default to True in future versions.")
+    def setNonce(self, newNonce):
+        if newNonce <= 0:
+            raise InvalidNonceException('Nonces must be positive')
+        if newNonce <= self.nonce:
+            raise InvalidNonceException('Nonces must be strictly increasing')
+        if newNonce > self.MAX_NONCE_VALUE:
+            raise InvalidNonceException('Nonces cannot be greater than %d' %
+                                        self.MAX_NONCE_VALUE)
+
+        self.nonce = newNonce
+
+        return self.nonce
+
+    def incrementNonce(self):
+        if self.nonce >= self.MAX_NONCE_VALUE:
+            raise InvalidNonceException('Cannot increment nonce, already at'
+                                        ' maximum value')
+
+        self.nonce += 1
+
+        return self.nonce
+
+
+class AbstractKeyHandler(object):
+    '''AbstractKeyHandler handles the tedious task of managing nonces
+    associated with BTC-e API key/secret pairs.
+    The getNextNonce method is threadsafe, all others need not be.'''
+    def __init__(self):
         self._keys = {}
-        self.resaveOnDeletion = False
-        self.filename = filename
-        if filename is not None:
-            self.resaveOnDeletion = resaveOnDeletion
-            f = open(filename, "rt")
-            while True:
-                key = f.readline().strip()
-                if not key:
-                    break
-                secret = f.readline().strip()
-                nonce = int(f.readline().strip())
-                self.addKey(key, secret, nonce)
-
-    def __del__(self):
-        self.close()
-
-    def close(self):
-        if self.resaveOnDeletion:
-            self.save(self.filename)
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        self.close()
+        self._loadKeys()
 
     @property
     def keys(self):
         return self._keys.keys()
 
     def getKeys(self):
-        return self._keys.keys()
+        return self.keys
 
-    def save(self, filename):
-        f = open(filename, "wt")
-        for k, data in self._keys.items():
-            f.write("%s\n%s\n%d\n" % (k, data.secret, data.nonce))
+    # Should load the keys with their secrets and nonces from the datastore
+    def _loadKeys(self):
+        raise NotImplementedError
+
+    # Should update the datastore with the latest data (newest nonces, and any
+    # keys that might have been added)
+    def _updateDatastore(self):
+        raise NotImplementedError
+
+    def __del__(self):
+        self.close()
+
+    def close(self):
+        self._updateDatastore()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        self.close()
 
     def addKey(self, key, secret, next_nonce):
         self._keys[key] = KeyData(secret, next_nonce)
+        return self
 
     def getNextNonce(self, key):
-        data = self._keys.get(key)
-        if data is None:
-            raise KeyError("Key not found: %r" % key)
-
-        nonce = data.nonce
-        data.nonce += 1
-
-        return nonce
+        return self.getKey(key).incrementNonce()
 
     def getSecret(self, key):
+        return self.getKey(key).secret
+
+    def setNextNonce(self, key, nextNonce):
+        return self.getKey(key).setNonce(nextNonce)
+
+    def getKey(self, key):
         data = self._keys.get(key)
         if data is None:
             raise KeyError("Key not found: %r" % key)
 
-        return data.secret
+        return data
 
-    def setNextNonce(self, key, next_nonce):
-        data = self._keys.get(key)
-        if data is None:
-            raise KeyError("Key not found: %r" % key)
-        data.nonce = next_nonce
+
+class KeyHandler(AbstractKeyHandler):
+    '''An implementation of AbstractKeyHandler using local files to store the
+    data.'''
+    def __init__(self, filename=None, resaveOnDeletion=True):
+        '''The given file is assumed to be a text file with three lines
+        (key, secret, nonce) per entry.'''
+        if not resaveOnDeletion:
+            warnings.warn("The resaveOnDeletion argument to KeyHandler will"
+                          " default to True in future versions.")
+
+        self.resaveOnDeletion = resaveOnDeletion
+        self.filename = filename
+        super(KeyHandler, self).__init__()
+
+    def _loadKeys(self):
+        if self.filename is not None:
+            self._parse()
+
+    def _updateDatastore(self):
+        if self.resaveOnDeletion and self.filename is not None:
+            self._save()
+
+    def _save(self):
+        with open(self.filename, 'wt') as file:
+            for k, data in self._keys.iteritems():
+                file.write("%s\n%s\n%d\n" % (k, data.secret, data.nonce))
+
+    def _parse(self):
+        with open(self.filename, 'rt') as input_file:
+            while True:
+                key = input_file.readline().strip()
+                if not key:
+                    break
+                secret = input_file.readline().strip()
+                nonce = int(input_file.readline().strip())
+                self.addKey(key, secret, nonce)

--- a/btceapi/trade.py
+++ b/btceapi/trade.py
@@ -132,8 +132,9 @@ class TradeAPI(object):
         self.key = key
         self.handler = handler
 
-        if not isinstance(self.handler, keyhandler.KeyHandler):
+        if not isinstance(self.handler, keyhandler.AbstractKeyHandler):
             raise TypeError("The handler argument must be a"
+                            " keyhandler.AbstractKeyHandler, such as"
                             " keyhandler.KeyHandler")
 
         # We depend on the key handler for the secret

--- a/test/test_common.py
+++ b/test/test_common.py
@@ -100,5 +100,6 @@ class TestCommon(unittest.TestCase):
 
         self.assertEqual(currencies_from_pairs, set(all_currencies))
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_keyhandler.py
+++ b/test/test_keyhandler.py
@@ -1,0 +1,121 @@
+import unittest
+import tempfile
+from btceapi.keyhandler import KeyData, AbstractKeyHandler, KeyHandler, InvalidNonceException
+
+
+class TestKeyData(unittest.TestCase):
+    def test_setNonce(self):
+        data = KeyData('secret', 1)
+
+        # happy path
+        newNonce = 28
+        self.assertEqual(data.setNonce(newNonce), newNonce)
+
+        # negative nonce
+        self.assertRaises(InvalidNonceException, data.setNonce, 0)
+
+        # non-increasing nonce
+        self.assertRaises(InvalidNonceException, data.setNonce, newNonce)
+
+        # over the max value
+        self.assertRaises(InvalidNonceException, data.setNonce, 4294967295)
+
+    def test_incrementNonce(self):
+        # happy path
+        self.assertEqual(KeyData('secret', 1).incrementNonce(), 2)
+
+        # over the max value
+        data = KeyData('secret', 4294967294)
+        self.assertRaises(InvalidNonceException, data.incrementNonce)
+
+
+# we need a dummy key handler class to test on
+class DummyKeyHandler(AbstractKeyHandler):
+    def __init__(self):
+        self.keysLoaded = False
+        self.datastoreUpdated = False
+        super(DummyKeyHandler, self).__init__()
+
+    def _loadKeys(self):
+        self.keysLoaded = True
+
+    def _updateDatastore(self):
+        self.datastoreUpdated = True
+
+
+class TestAbstractKeyHandler(unittest.TestCase):
+    def test_init(self):
+        # test it loads the keys from the datastore
+        handler = DummyKeyHandler()
+        assert handler.keysLoaded
+
+    def test_keys(self):
+        # incidentally tests addKey, too
+        self.assertEqual(self._handler_with_keys().keys, ['k2', 'k1'])
+
+    def test___del__(self):
+        handler = DummyKeyHandler()
+        handler.__del__()
+        assert handler.datastoreUpdated
+
+    def test___exit__(self):
+        handler = DummyKeyHandler()
+        handler.__exit__('type', 'value', 'traceback')
+        assert handler.datastoreUpdated
+
+    def test_close(self):
+        handler = DummyKeyHandler()
+        handler.close()
+        assert handler.datastoreUpdated
+
+    def test___enter__(self):
+        handler = DummyKeyHandler()
+        self.assertEqual(handler.__enter__(), handler)
+
+    def test_getKey(self):
+        handler = self._handler_with_keys()
+
+        # happy path
+        self.assertEqual(handler.getKey('k1').nonce, 3)
+
+        # unknown key
+        self.assertRaises(KeyError, handler.getNextNonce, 'i_dont_exist')
+
+    def test_getNextNonce(self):
+        self.assertEqual(self._handler_with_keys().getNextNonce('k2'), 29)
+
+    def test_setNextNonce(self):
+        self.assertEqual(self._handler_with_keys().setNextNonce('k1', 82), 82)
+
+
+    def _handler_with_keys(self):
+        handler = DummyKeyHandler()
+        return handler.addKey('k1', 'secret1', 3).addKey('k2', 'secret2', 28)
+
+
+class TestKeyHandler(unittest.TestCase):
+    def test_save(self):
+        _, filename = tempfile.mkstemp()
+
+        handler = KeyHandler(filename=filename)
+        handler.addKey('k1', 'secret1', 3).addKey('k2', 'secret2', 28)
+
+        handler.close()
+
+        expected_content = 'k2\nsecret2\n28\nk1\nsecret1\n3\n'
+        with open(filename) as saved_file:
+            self.assertEqual(saved_file.read(), expected_content)
+
+    def test_parse(self):
+        _, filename = tempfile.mkstemp()
+
+        with open(filename, 'w') as input_file:
+            input_file.write('k2\nsecret2\n28\nk1\nsecret1\n3\n')
+
+        handler = KeyHandler(filename=filename)
+
+        self.assertEqual(handler.keys, ['k2', 'k1'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_public.py
+++ b/test/test_public.py
@@ -61,5 +61,6 @@ class TestPublic(unittest.TestCase):
         self.assertEqual(t.date,
                          datetime.datetime(2013, 5, 17, 8, 48, 4, 878004))
 
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The `KeyHandler` class, as it was, made it impossible to use anything
else than files as data store for the keys' data. This patch extracts
the logic common to all key handlers in a separate base class, named
`AbstractKeyHandler`, and makes `KeyHandler` inherit from it.

That way, it is now possible to use other data stores for key handlers,
such as databases; or even to define totally different key handlers,
e.g. one that would compute nonces based on timestamps.

Also added a check for the maximum value of nonces.

Added unit tests on all of that.